### PR TITLE
docs: Fix ADC authentication setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ The server needs credentials to access Google APIs. Choose one method:
     2.  `gcloud auth application-default login` credentials (local development)
     3.  Attached service account from metadata server (GKE, Compute Engine, etc.)
 *   **Setup:**
-    *   **Local Development:** Run `gcloud auth application-default login` once
+    *   **Local Development:** 
+        1. Run `gcloud auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive` once
+        2. Set a quota project: `gcloud auth application-default set-quota-project <project_id>` (replace `<project_id>` with your Google Cloud project ID)
     *   **Google Cloud:** Attach a service account to your compute resource
     *   **Environment Variable:** Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json` (Google's standard)
 *   **No additional environment variables needed** - ADC is used automatically as a fallback when other methods fail.
@@ -409,7 +411,9 @@ Add the server config to `claude_desktop_config.json` under `mcpServers`. Choose
   }
 }
 ```
-*Prerequisites: Run `gcloud auth application-default login` first.*
+*Prerequisites:* 
+1. *Run `gcloud auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive` first.*
+2. *Set quota project: `gcloud auth application-default set-quota-project <project_id>`*
 
 **🍎 macOS Note:** If you get a `spawn uvx ENOENT` error, replace `"command": "uvx"` with `"command": "/Users/yourusername/.local/bin/uvx"` (replace `yourusername` with your actual username).
 </details>


### PR DESCRIPTION
Fixes the ADC authentication setup instructions by adding the required scopes and quota project configuration.

- Add required scopes to `gcloud auth application-default login` command
- Add quota project setup step with `gcloud auth application-default set-quota-project`
- Update Claude Desktop config prerequisites to include both commands

Fixes #29