### PR TITLE
feat: add include_grid_data to get_sheet_data and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ This server exposes the following tools for interacting with Google Sheets:
     *   `spreadsheet_id` (string)
     *   `sheet` (string): Name of the sheet.
     *   `range` (optional string): A1 notation (e.g., `'A1:C10'`, `'Sheet1!B2:D'`). If omitted, reads the whole sheet.
-    *   _Returns:_ Full grid data structure from Google Sheets API with all metadata preserved.
+    *   `include_grid_data` (optional boolean, default False): If True, includes cell formatting and other metadata (larger response). If False, returns values only (more efficient).
+    *   _Returns:_ If `include_grid_data=True`, full grid data with metadata. If `False`, a values result object from the Values API.
 *   **`get_sheet_formulas`**: Reads formulas from a range in a sheet.
     *   `spreadsheet_id` (string)
     *   `sheet` (string): Name of the sheet.


### PR DESCRIPTION
- Add optional boolean `include_grid_data` to [get_sheet_data](/src/mcp_google_sheets/server.py:124:0-175:17)
  - True: use Sheets API with `includeGridData` to return full grid data with metadata
  - False (default): use Values API to return values only (more efficient)
- Update docstring and README to document the new parameter and differing return shapes