### PR TITLE
fix(server): change main to async def

### DIFF
--- a/src/mcp_google_sheets/server.py
+++ b/src/mcp_google_sheets/server.py
@@ -928,6 +928,6 @@ def share_spreadsheet(spreadsheet_id: str,
             
     return {"successes": successes, "failures": failures}
 
-def main():
+async def main():
     # Run the server
     mcp.run()


### PR DESCRIPTION
server.main was defined as a sync function returning None, which caused
 when executed with
asyncio.run(). Updated to  so the entrypoint works properly with asyncio.