### PR TITLE
chore: Add fallback version for cases when I do not have tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ source = "uv-dynamic-versioning"
 [tool.uv-dynamic-versioning]
 pattern = "default"
 strict = true
+fallback-version = "0.0.0"
 
 [project.scripts]
 mcp-google-sheets = "mcp_google_sheets:main"


### PR DESCRIPTION
Thank you for this easy to setup MCP server!

I faced a small issue when I forked repo and attempted to run it with `uv run --directory . mcp-google-sheets`:

```
$ uv run --directory . mcp-google-sheets
Using CPython 3.13.7 interpreter at: /usr/bin/python3.13
Creating virtual environment at: .venv
  × Failed to build `mcp-google-sheets @ file:///home/jhutar/Checkouts/mcp-google-sheets`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename = backend.build_editable("/home/jhutar/.cache/uv/builds-v0/.tmpiU2s69", {}, None)
        File "/home/jhutar/.cache/uv/builds-v0/.tmppxYC0a/lib64/python3.13/site-packages/hatchling/build.py", line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['editable'])))
                                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/jhutar/.cache/uv/builds-v0/.tmppxYC0a/lib64/python3.13/site-packages/hatchling/builders/plugin/interface.py", line 90, in build
          self.metadata.validate_fields()
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
        File "/home/jhutar/.cache/uv/builds-v0/.tmppxYC0a/lib64/python3.13/site-packages/hatchling/metadata/core.py", line 265, in validate_fields
          _ = self.version
              ^^^^^^^^^^^^
        File "/home/jhutar/.cache/uv/builds-v0/.tmppxYC0a/lib64/python3.13/site-packages/hatchling/metadata/core.py", line 149, in version
          self._version = self._get_version()
                          ~~~~~~~~~~~~~~~~~^^
        File "/home/jhutar/.cache/uv/builds-v0/.tmppxYC0a/lib64/python3.13/site-packages/hatchling/metadata/core.py", line 248, in _get_version
          version = self.hatch.version.cached
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/jhutar/.cache/uv/builds-v0/.tmppxYC0a/lib64/python3.13/site-packages/hatchling/metadata/core.py", line 1456, in cached
          raise type(e)(message) from None
      RuntimeError: Error getting the version from source `uv-dynamic-versioning`: No tags available and fallbacks disabled by strict mode

      hint: This usually indicates a problem with the package or the build environment.
```

Looking at https://pydevtools.com/handbook/how-to/how-to-add-dynamic-versioning-to-uv-projects/ I added this line and it fixed the issue.

Please consider this for merging.