### PR TITLE
feat: optionally gate spreadsheet tools on service-account sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ wheels/
 
 # Virtual environments
 .venv
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -327,12 +327,16 @@ _Refer to the [ID Reference Guide](#-id-reference-guide) for more information ab
         *   `CREDENTIALS_PATH`: Path to the downloaded OAuth credentials JSON file (default: `credentials.json`).
         *   `TOKEN_PATH`: Path to store the user's refresh token after first login (default: `token.json`). Must be writable.
 
+
+**Rolling this out to multiple users (e.g. everyone at a company)?** The OAuth Client ID from step 2 is shared, not per-user - Google's own guidance for this "Desktop app" client type doesn't treat its secret as confidential (it can't be kept secret on an end-user device anyway), so distributing the same downloaded JSON to every machine (via your existing install/config process) is a fully supported pattern. Each person just does their own one-time browser consent, which produces their own local `token.json`. If your OAuth consent screen is set to **Internal** (available when everyone is in the same Google Workspace domain), it also skips Google's app-verification review entirely.
+
 ### Method C: Direct Credential Injection (Advanced) 🔒
 
 *   **Why?** Useful in environments like Docker, Kubernetes, or CI/CD where managing files is hard, but environment variables are easy/secure. Avoids file system access.
 *   **How?** Instead of providing a *path* to the credentials file, you provide the *content* of the file, encoded in Base64, directly in an environment variable.
+*   **Note:** `CREDENTIALS_CONFIG` currently only supports **Service Account** key JSON, not OAuth Client ID JSON.
 *   **Steps:**
-    1.  **Get your credentials JSON file** (either Service Account key or OAuth Client ID file). Let's call it `your_credentials.json`.
+    1.  **Get your Service Account key JSON file.** Let's call it `your_credentials.json`.
     2.  **Generate the Base64 string:**
         *   **(Linux/macOS):** `base64 -w 0 your_credentials.json`
         *   **(Windows PowerShell):**
@@ -372,7 +376,7 @@ _Refer to the [ID Reference Guide](#-id-reference-guide) for more information ab
 
 The server checks for credentials in this order:
 
-1.  `CREDENTIALS_CONFIG` (Base64 content)
+1.  `CREDENTIALS_CONFIG` (Base64 content, Service Account only)
 2.  `SERVICE_ACCOUNT_PATH` (Path to Service Account JSON)
 3.  `CREDENTIALS_PATH` (Path to OAuth JSON) - triggers interactive flow if token is missing/expired
 4.  **Application Default Credentials (ADC)** - automatic fallback
@@ -386,7 +390,25 @@ The server checks for credentials in this order:
 | `DRIVE_FOLDER_ID`                | Service Account             | ID of the Google Drive folder shared with the Service Account.   | -                  |
 | `CREDENTIALS_PATH`               | OAuth 2.0                   | Path to the OAuth 2.0 Client ID JSON file.                       | `credentials.json` |
 | `TOKEN_PATH`                     | OAuth 2.0                   | Path to store the generated OAuth token.                         | `token.json`       |
-| `CREDENTIALS_CONFIG`             | Service Account / OAuth 2.0 | Base64 encoded JSON string of credentials content.               | -                  |
+| `CREDENTIALS_CONFIG`             | Service Account             | Base64 encoded JSON string of Service Account key content.       | -                  |
+| `SERVICE_ACCOUNT_EMAIL`          | Any (optional gate)         | See [Restricting Access via a Sharing Gate](#-restricting-access-via-a-sharing-gate-optional) below. | -   |
+
+---
+
+## 🔒 Restricting Access via a Sharing Gate (Optional)
+
+If you authenticate as an end user (OAuth or `gcloud auth application-default login`, i.e. Methods B/D above) rather than a Service Account key, the server calls the Sheets/Drive APIs **as you** - meaning it can technically reach anything your Google account can reach. `SERVICE_ACCOUNT_EMAIL` lets you narrow that down to an explicit allowlist, using the same "share it with this account" gesture as the Service Account method, without actually needing the service account to hold real API access.
+
+**How it works:**
+
+*   Set `SERVICE_ACCOUNT_EMAIL` to a service account's email address (it doesn't need a key file - it's used purely as an identity to check for, e.g. `mcp-google-sheets@your-project.iam.gserviceaccount.com`).
+*   Before any tool touches a spreadsheet, the server checks (via the Drive API, using your own credentials) whether that spreadsheet is shared with `SERVICE_ACCOUNT_EMAIL`. If not, the call fails with a message telling you exactly which account to share it with.
+*   The role you shared it with matters too: **Viewer** access allows read-only tools (`get_sheet_data`, `list_sheets`, `find_in_spreadsheet`, etc.); **Editor** access is required for anything that writes (`update_cells`, `add_rows`, `create_sheet`, `share_spreadsheet`, etc.). Sharing as Viewer but calling a write tool fails with a clear "read-only" error instead of silently attempting the write.
+*   `create_spreadsheet` automatically shares any spreadsheet it creates with `SERVICE_ACCOUNT_EMAIL` as an Editor, so newly created sheets are immediately usable by other tools. Pass `share_with_service_account=false` to opt out for a given call.
+*   Sharing checks are cached per spreadsheet for the life of the server process, so repeated calls don't re-check on every invocation.
+*   **Leave `SERVICE_ACCOUNT_EMAIL` unset and none of this applies** - every tool behaves exactly as it did before this feature existed, with no extra API calls or restrictions.
+
+This is an app-level allowlist, not a Google-enforced ACL boundary - it's enforced by this server's code, not by Google's permission system, so it's a defense-in-depth measure rather than a hard security boundary. It's most useful for keeping an AI tool scoped to a known set of sheets even though the underlying credentials could technically reach more.
 
 ---
 

--- a/src/mcp_google_sheets/server.py
+++ b/src/mcp_google_sheets/server.py
@@ -34,6 +34,13 @@ CREDENTIALS_CONFIG = os.environ.get('CREDENTIALS_CONFIG')
 TOKEN_PATH = os.environ.get('TOKEN_PATH', 'token.json')
 CREDENTIALS_PATH = os.environ.get('CREDENTIALS_PATH', 'credentials.json')
 SERVICE_ACCOUNT_PATH = os.environ.get('SERVICE_ACCOUNT_PATH', 'service_account.json')
+# Optional gating service account. When set, every spreadsheet operation is checked
+# against this account's Drive sharing entry before it runs (and the granted role -
+# reader/writer/etc - determines whether write operations are allowed). When unset,
+# every tool behaves exactly as it did before this feature existed: no extra checks,
+# no extra API calls, no lookups of any kind.
+SERVICE_ACCOUNT_EMAIL = os.environ.get('SERVICE_ACCOUNT_EMAIL')
+
 DRIVE_FOLDER_ID = os.environ.get('DRIVE_FOLDER_ID', '')  # Working directory in Google Drive
 
 
@@ -79,6 +86,90 @@ class SpreadsheetContext:
     sheets_service: Any
     drive_service: Any
     folder_id: Optional[str] = None
+    service_account_email: Optional[str] = None
+    _shared_role_cache: Dict[str, str] = None
+
+    def __post_init__(self):
+        if self._shared_role_cache is None:
+            self._shared_role_cache = {}
+
+
+class ServiceAccountShareRequired(PermissionError):
+    """Raised when a spreadsheet operation is blocked by the gating service account's sharing/role."""
+
+
+# Drive permission roles, ordered from least to most access.
+_DRIVE_ROLE_RANK = {
+    'reader': 0,
+    'commenter': 1,
+    'writer': 2,
+    'fileOrganizer': 3,
+    'organizer': 4,
+    'owner': 5,
+}
+_MIN_WRITE_ROLE_RANK = _DRIVE_ROLE_RANK['writer']
+
+
+def _verify_shared_with_service_account(
+    lifespan_context: "SpreadsheetContext", spreadsheet_id: str, write: bool = False
+) -> None:
+    """
+    No-op unless a gating service account (SERVICE_ACCOUNT_EMAIL) is configured.
+
+    When configured, raises ServiceAccountShareRequired unless spreadsheet_id is
+    shared with that account - and, for write operations, unless the granted role
+    is 'writer' or higher.
+    """
+    sa_email = lifespan_context.service_account_email
+    if not sa_email:
+        return
+
+    role = lifespan_context._shared_role_cache.get(spreadsheet_id)
+    if role is None:
+        try:
+            permissions: List[Dict[str, Any]] = []
+            page_token = None
+            while True:
+                resp = lifespan_context.drive_service.permissions().list(
+                    fileId=spreadsheet_id,
+                    fields="nextPageToken, permissions(emailAddress, role)",
+                    pageToken=page_token,
+                    supportsAllDrives=True,
+                ).execute()
+                permissions.extend(resp.get('permissions', []))
+                page_token = resp.get('nextPageToken')
+                if not page_token:
+                    break
+        except Exception as e:
+            raise ServiceAccountShareRequired(
+                f"Could not verify sharing permissions for spreadsheet '{spreadsheet_id}': {e}"
+            )
+
+        match = next(
+            (p for p in permissions if (p.get('emailAddress') or '').lower() == sa_email.lower()),
+            None
+        )
+        if not match:
+            raise ServiceAccountShareRequired(
+                f"Spreadsheet '{spreadsheet_id}' is not shared with the service account '{sa_email}'. "
+                f"Share it with that account (Viewer for read access, Editor for write access) and try again."
+            )
+        role = match.get('role', 'reader')
+        lifespan_context._shared_role_cache[spreadsheet_id] = role
+
+    if write and _DRIVE_ROLE_RANK.get(role, -1) < _MIN_WRITE_ROLE_RANK:
+        raise ServiceAccountShareRequired(
+            f"Spreadsheet '{spreadsheet_id}' is shared with the service account '{sa_email}' as "
+            f"'{role}', which only allows read access. Share it with Editor (writer) access to "
+            f"perform this operation."
+        )
+
+
+def _require_shared(ctx: Context, spreadsheet_id: str, write: bool = False) -> None:
+    """Tool-facing helper: verify sharing/role using the Context passed by FastMCP."""
+    _verify_shared_with_service_account(ctx.request_context.lifespan_context, spreadsheet_id, write=write)
+
+
 
 
 @asynccontextmanager
@@ -158,12 +249,18 @@ async def spreadsheet_lifespan(server: FastMCP) -> AsyncIterator[SpreadsheetCont
     sheets_service = build('sheets', 'v4', credentials=creds, cache_discovery=False)
     drive_service = build('drive', 'v3', credentials=creds, cache_discovery=False)
     
+    # Optional gating service account: no lookups, just the env var as-is. When unset,
+    # every tool behaves exactly as it did before this feature existed.
+    if SERVICE_ACCOUNT_EMAIL:
+        logger.info("Gating spreadsheet access on sharing with service account: %s", SERVICE_ACCOUNT_EMAIL)
+
     try:
         # Provide the service in the context
         yield SpreadsheetContext(
             sheets_service=sheets_service,
             drive_service=drive_service,
-            folder_id=DRIVE_FOLDER_ID if DRIVE_FOLDER_ID else None
+            folder_id=DRIVE_FOLDER_ID if DRIVE_FOLDER_ID else None,
+            service_account_email=SERVICE_ACCOUNT_EMAIL,
         )
     finally:
         # No explicit cleanup needed for Google APIs
@@ -244,6 +341,7 @@ def get_sheet_data(spreadsheet_id: str,
     Returns:
         Grid data structure with either full metadata or just values from Google Sheets API, depending on include_grid_data parameter
     """
+    _require_shared(ctx, spreadsheet_id)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
 
     # Construct the range - keep original API behavior
@@ -298,6 +396,7 @@ def get_sheet_formulas(spreadsheet_id: str,
     Returns:
         A 2D array of the sheet formulas.
     """
+    _require_shared(ctx, spreadsheet_id)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Construct the range
@@ -340,6 +439,7 @@ def update_cells(spreadsheet_id: str,
     Returns:
         Result of the update operation
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Construct the range
@@ -383,6 +483,7 @@ def batch_update_cells(spreadsheet_id: str,
     Returns:
         Result of the batch update operation
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Prepare the batch update request
@@ -431,6 +532,7 @@ def add_rows(spreadsheet_id: str,
     Returns:
         Result of the operation
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Get sheet ID
@@ -494,6 +596,7 @@ def add_columns(spreadsheet_id: str,
     Returns:
         Result of the operation
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Get sheet ID
@@ -550,6 +653,7 @@ def list_sheets(spreadsheet_id: str, ctx: Context = None) -> List[str]:
     Returns:
         List of sheet names
     """
+    _require_shared(ctx, spreadsheet_id)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Get spreadsheet metadata
@@ -584,6 +688,8 @@ def copy_sheet(src_spreadsheet: str,
     Returns:
         Result of the operation
     """
+    _require_shared(ctx, src_spreadsheet)
+    _require_shared(ctx, dst_spreadsheet, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Get source sheet ID
@@ -661,6 +767,7 @@ def rename_sheet(spreadsheet: str,
     Returns:
         Result of the operation
     """
+    _require_shared(ctx, spreadsheet, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Get sheet ID
@@ -733,6 +840,8 @@ def get_multiple_sheet_data(queries: List[Dict[str, str]],
             continue
 
         try:
+            _require_shared(ctx, spreadsheet_id)
+
             # Construct the range
             full_range = f"{sheet}!{range_str}"
             
@@ -784,6 +893,8 @@ def get_multiple_spreadsheet_summary(spreadsheet_ids: List[str],
             'error': None
         }
         try:
+            _require_shared(ctx, spreadsheet_id)
+
             # Get spreadsheet metadata
             spreadsheet = sheets_service.spreadsheets().get(
                 spreadsheetId=spreadsheet_id,
@@ -859,6 +970,7 @@ def get_spreadsheet_info(spreadsheet_id: str) -> str:
     """
     # Access the context through mcp.get_lifespan_context() for resources
     context = mcp.get_lifespan_context()
+    _verify_shared_with_service_account(context, spreadsheet_id)
     sheets_service = context.sheets_service
     
     # Get spreadsheet metadata
@@ -886,21 +998,28 @@ def get_spreadsheet_info(spreadsheet_id: str) -> str:
         destructiveHint=True,
     ),
 )
-def create_spreadsheet(title: str, folder_id: Optional[str] = None, ctx: Context = None) -> Dict[str, Any]:
+def create_spreadsheet(title: str, folder_id: Optional[str] = None,
+                       share_with_service_account: bool = True,
+                       ctx: Context = None) -> Dict[str, Any]:
     """
     Create a new Google Spreadsheet.
-    
+
     Args:
         title: The title of the new spreadsheet
         folder_id: Optional Google Drive folder ID where the spreadsheet should be created.
                   If not provided, uses the configured default folder or creates in root.
-    
+        share_with_service_account: If a gating service account (SERVICE_ACCOUNT_EMAIL) is
+                  configured, automatically share the new spreadsheet with it as a writer so
+                  it's immediately usable by other tools. Has no effect if no gating service
+                  account is configured. Defaults to True.
+
     Returns:
         Information about the newly created spreadsheet including its ID
     """
-    drive_service = ctx.request_context.lifespan_context.drive_service
+    lifespan_context = ctx.request_context.lifespan_context
+    drive_service = lifespan_context.drive_service
     # Use provided folder_id or fall back to configured default
-    target_folder_id = folder_id or ctx.request_context.lifespan_context.folder_id
+    target_folder_id = folder_id or lifespan_context.folder_id
 
     # Create the spreadsheet
     file_body = {
@@ -909,7 +1028,7 @@ def create_spreadsheet(title: str, folder_id: Optional[str] = None, ctx: Context
     }
     if target_folder_id:
         file_body['parents'] = [target_folder_id]
-    
+
     spreadsheet = drive_service.files().create(
         supportsAllDrives=True,
         body=file_body,
@@ -921,10 +1040,27 @@ def create_spreadsheet(title: str, folder_id: Optional[str] = None, ctx: Context
     folder_info = f" in folder {target_folder_id}" if target_folder_id else " in root"
     logger.info("Spreadsheet created with ID: %s%s", spreadsheet_id, folder_info)
 
+    shared_with_service_account = False
+    sa_email = lifespan_context.service_account_email
+    if sa_email and share_with_service_account:
+        try:
+            drive_service.permissions().create(
+                fileId=spreadsheet_id,
+                body={'type': 'user', 'role': 'writer', 'emailAddress': sa_email},
+                sendNotificationEmail=False,
+                fields='id',
+            ).execute()
+            lifespan_context._shared_role_cache[spreadsheet_id] = 'writer'
+            shared_with_service_account = True
+            logger.info("Shared new spreadsheet %s with service account %s (writer)", spreadsheet_id, sa_email)
+        except Exception as e:
+            logger.error("Failed to share new spreadsheet %s with service account %s: %s", spreadsheet_id, sa_email, e)
+
     return {
         'spreadsheetId': spreadsheet_id,
         'title': spreadsheet.get('name', title),
         'folder': parents[0] if parents else 'root',
+        'sharedWithServiceAccount': shared_with_service_account,
     }
 
 
@@ -947,6 +1083,7 @@ def create_sheet(spreadsheet_id: str,
     Returns:
         Information about the newly created sheet
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Define the add sheet request
@@ -1052,6 +1189,7 @@ def share_spreadsheet(spreadsheet_id: str,
         A dictionary containing lists of 'successes' and 'failures'. 
         Each item in the lists includes the email address and the outcome.
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     drive_service = ctx.request_context.lifespan_context.drive_service
     successes = []
     failures = []
@@ -1372,6 +1510,8 @@ def find_in_spreadsheet(spreadsheet_id: str,
     results = []
 
     try:
+        _require_shared(ctx, spreadsheet_id)
+
         # Get spreadsheet metadata to find all sheets
         spreadsheet = sheets_service.spreadsheets().get(
             spreadsheetId=spreadsheet_id,
@@ -1488,6 +1628,7 @@ def batch_update(spreadsheet_id: str,
     Returns:
         Result of the batch update operation, including replies for each request
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Validate input
@@ -1581,6 +1722,7 @@ def add_chart(spreadsheet_id: str,
             title="Market Share by Product"
         )
     """
+    _require_shared(ctx, spreadsheet_id, write=True)
     sheets_service = ctx.request_context.lifespan_context.sheets_service
     
     # Validate chart type

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -119,19 +119,40 @@ class RecordingFilesResource:
         return FakeRequest(self.list_result)
 
 
+class RecordingPermissionsResource:
+    def __init__(self):
+        self.calls = []
+        self.list_result = {"permissions": []}
+        self.create_result = {"id": "permission-id"}
+
+    def list(self, **kwargs):
+        self.calls.append(("permissions.list", kwargs))
+        return FakeRequest(self.list_result)
+
+    def create(self, **kwargs):
+        self.calls.append(("permissions.create", kwargs))
+        return FakeRequest(self.create_result)
+
+
 class RecordingDriveService:
     def __init__(self):
         self.files_resource = RecordingFilesResource()
+        self.permissions_resource = RecordingPermissionsResource()
 
     def files(self):
         return self.files_resource
 
+    def permissions(self):
+        return self.permissions_resource
 
-def fake_ctx(sheets_service=None, drive_service=None, folder_id=None):
+
+def fake_ctx(sheets_service=None, drive_service=None, folder_id=None, service_account_email=None):
     lifespan_context = SimpleNamespace(
         sheets_service=sheets_service,
         drive_service=drive_service,
         folder_id=folder_id,
+        service_account_email=service_account_email,
+        _shared_role_cache={},
     )
     request_context = SimpleNamespace(lifespan_context=lifespan_context)
     return SimpleNamespace(request_context=request_context)
@@ -395,6 +416,7 @@ class ToolRequestConstructionTests(unittest.TestCase):
                 "spreadsheetId": "spreadsheet-id",
                 "title": "Created Sheet",
                 "folder": "folder-id",
+                "sharedWithServiceAccount": False,
             },
         )
         self.assertEqual(
@@ -517,6 +539,114 @@ class ToolRequestConstructionTests(unittest.TestCase):
                 "heightPixels": 200,
             },
         )
+
+
+
+class ServiceAccountGatingTests(unittest.TestCase):
+    SA_EMAIL = "mcp-google-sheets@fresh-aura-503719-f6.iam.gserviceaccount.com"
+
+    def _lifespan(self, service_account_email=None):
+        drive_service = RecordingDriveService()
+        ctx = fake_ctx(drive_service=drive_service, service_account_email=service_account_email)
+        return ctx.request_context.lifespan_context, drive_service
+
+    def test_noop_when_no_service_account_configured(self):
+        lifespan_context, drive_service = self._lifespan(service_account_email=None)
+
+        server._verify_shared_with_service_account(lifespan_context, "sheet-id", write=True)
+
+        self.assertEqual(drive_service.permissions_resource.calls, [])
+
+    def test_raises_when_not_shared_with_service_account(self):
+        lifespan_context, drive_service = self._lifespan(service_account_email=self.SA_EMAIL)
+        drive_service.permissions_resource.list_result = {"permissions": [
+            {"emailAddress": "someone-else@example.com", "role": "writer"},
+        ]}
+
+        with self.assertRaises(server.ServiceAccountShareRequired):
+            server._verify_shared_with_service_account(lifespan_context, "sheet-id")
+
+    def test_read_allowed_when_shared_as_reader(self):
+        lifespan_context, drive_service = self._lifespan(service_account_email=self.SA_EMAIL)
+        drive_service.permissions_resource.list_result = {"permissions": [
+            {"emailAddress": self.SA_EMAIL, "role": "reader"},
+        ]}
+
+        server._verify_shared_with_service_account(lifespan_context, "sheet-id", write=False)
+
+    def test_write_blocked_when_shared_as_reader_only(self):
+        lifespan_context, drive_service = self._lifespan(service_account_email=self.SA_EMAIL)
+        drive_service.permissions_resource.list_result = {"permissions": [
+            {"emailAddress": self.SA_EMAIL, "role": "reader"},
+        ]}
+
+        with self.assertRaises(server.ServiceAccountShareRequired):
+            server._verify_shared_with_service_account(lifespan_context, "sheet-id", write=True)
+
+    def test_write_allowed_when_shared_as_writer(self):
+        lifespan_context, drive_service = self._lifespan(service_account_email=self.SA_EMAIL)
+        drive_service.permissions_resource.list_result = {"permissions": [
+            {"emailAddress": self.SA_EMAIL, "role": "writer"},
+        ]}
+
+        server._verify_shared_with_service_account(lifespan_context, "sheet-id", write=True)
+
+    def test_permission_lookup_is_cached_per_spreadsheet(self):
+        lifespan_context, drive_service = self._lifespan(service_account_email=self.SA_EMAIL)
+        drive_service.permissions_resource.list_result = {"permissions": [
+            {"emailAddress": self.SA_EMAIL, "role": "writer"},
+        ]}
+
+        server._verify_shared_with_service_account(lifespan_context, "sheet-id", write=True)
+        server._verify_shared_with_service_account(lifespan_context, "sheet-id", write=False)
+
+        list_calls = [c for c in drive_service.permissions_resource.calls if c[0] == "permissions.list"]
+        self.assertEqual(len(list_calls), 1)
+
+    def test_update_cells_blocked_when_spreadsheet_not_shared(self):
+        sheets_service = RecordingSheetsService()
+        drive_service = RecordingDriveService()
+        ctx = fake_ctx(sheets_service=sheets_service, drive_service=drive_service,
+                       service_account_email=self.SA_EMAIL)
+
+        with self.assertRaises(server.ServiceAccountShareRequired):
+            server.update_cells("spreadsheet-id", "Sheet1", "A1:B2", [[1, 2]], ctx=ctx)
+
+    def test_create_spreadsheet_auto_shares_with_configured_service_account(self):
+        drive_service = RecordingDriveService()
+        ctx = fake_ctx(drive_service=drive_service, service_account_email=self.SA_EMAIL)
+
+        with patch.object(server.logger, "info"):
+            result = server.create_spreadsheet("Created Sheet", ctx=ctx)
+
+        self.assertTrue(result["sharedWithServiceAccount"])
+        create_calls = [c for c in drive_service.permissions_resource.calls if c[0] == "permissions.create"]
+        self.assertEqual(len(create_calls), 1)
+        self.assertEqual(create_calls[0][1]["body"], {
+            "type": "user", "role": "writer", "emailAddress": self.SA_EMAIL,
+        })
+
+    def test_create_spreadsheet_skips_sharing_when_flag_false(self):
+        drive_service = RecordingDriveService()
+        ctx = fake_ctx(drive_service=drive_service, service_account_email=self.SA_EMAIL)
+
+        with patch.object(server.logger, "info"):
+            result = server.create_spreadsheet(
+                "Created Sheet", share_with_service_account=False, ctx=ctx
+            )
+
+        self.assertFalse(result["sharedWithServiceAccount"])
+        self.assertEqual(drive_service.permissions_resource.calls, [])
+
+    def test_create_spreadsheet_no_effect_when_service_account_not_configured(self):
+        drive_service = RecordingDriveService()
+        ctx = fake_ctx(drive_service=drive_service, service_account_email=None)
+
+        with patch.object(server.logger, "info"):
+            result = server.create_spreadsheet("Created Sheet", ctx=ctx)
+
+        self.assertFalse(result["sharedWithServiceAccount"])
+        self.assertEqual(drive_service.permissions_resource.calls, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add optional `SERVICE_ACCOUNT_EMAIL` gate: tools only operate on spreadsheets shared with that account
- Enforce Viewer vs Editor roles for read vs write
- Auto-share new spreadsheets created while the gate is enabled (opt-out via `share_with_service_account=false`)

## Test plan
- [ ] Unit tests pass (`uv run python -m unittest tests.test_server_unit`)
- [ ] With `SERVICE_ACCOUNT_EMAIL` unset, existing OAuth/ADC behavior is unchanged
- [ ] With it set, unshared spreadsheet calls fail with a clear share message
- [ ] Viewer-only share allows reads and blocks writes
- [ ] `create_spreadsheet` shares as Editor by default